### PR TITLE
fish: minor fixes

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -308,7 +308,7 @@ in
 
           # Source initialization code if it exists.
           if test -d $plugin_dir"/conf.d"
-            source $plugin_dir"/conf.d/*.fish"
+            source $plugin_dir/conf.d/*.fish
           end
 
           if test -f $plugin_dir"/key_bindings.fish"

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -227,7 +227,7 @@ in
       # if we haven't sourced the general config, do it
       if not set -q __fish_general_config_sourced
 
-        set fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions $fish_function_path
+        set -p fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions
         fenv source ${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh > /dev/null
         set -e fish_function_path[1]
 

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -28,13 +28,12 @@ let
     };
   });
 
-  abbrsStr = concatStringsSep "\n" (
-    mapAttrsToList (k: v: "abbr --add --global ${k} '${v}'") cfg.shellAbbrs
-  );
+  abbrsStr = concatStringsSep "\n"
+    (mapAttrsToList (k: v: "abbr --add --global -- ${k} ${escapeShellArg v}")
+      cfg.shellAbbrs);
 
-  aliasesStr = concatStringsSep "\n" (
-    mapAttrsToList (k: v: "alias ${k}='${v}'") cfg.shellAliases
-  );
+  aliasesStr = concatStringsSep "\n"
+    (mapAttrsToList (k: v: "alias ${k} ${escapeShellArg v}") cfg.shellAliases);
 
 in
 

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -53,7 +53,7 @@ in
 
       shellAliases = mkOption {
         type = with types; attrsOf str;
-        default = {};
+        default = { };
         example = { ".." = "cd .."; ll = "ls -l"; };
         description = ''
           An attribute set that maps aliases (the top level attribute names
@@ -63,8 +63,11 @@ in
 
       shellAbbrs = mkOption {
         type = with types; attrsOf str;
-        default = {};
-        example = { l = "less"; gco = "git checkout"; };
+        default = { };
+        example = {
+          l = "less";
+          gco = "git checkout";
+        };
         description = ''
           An attribute set that maps aliases (the top level attribute names
           in this option) to abbreviations. Abbreviations are expanded with
@@ -110,7 +113,7 @@ in
 
     programs.fish.plugins = mkOption {
       type = types.listOf pluginModule;
-      default = [];
+      default = [ ];
       example = literalExample ''
         [
           {
@@ -143,7 +146,7 @@ in
 
     programs.fish.functions = mkOption {
       type = types.attrsOf types.lines;
-      default = {};
+      default = { };
       example = { gitignore = "curl -sL https://www.gitignore.io/api/$argv"; };
       description = ''
         Basic functions to add to fish. For more information see
@@ -297,25 +300,25 @@ in
           set -l plugin_dir ${plugin.src}
 
           # Set paths to import plugin components
-          if test -d $plugin_dir"/functions"
-            set fish_function_path $fish_function_path[1] $plugin_dir"/functions" $fish_function_path[2..-1]
+          if test -d $plugin_dir/functions
+            set fish_function_path $fish_function_path[1] $plugin_dir/functions $fish_function_path[2..-1]
           end
 
-          if test -d $plugin_dir"/completions"
-            set fish_complete_path $fish_function_path[1] $plugin_dir"/completions" $fish_complete_path[2..-1]
+          if test -d $plugin_dir/completions
+            set fish_complete_path $fish_function_path[1] $plugin_dir/completions $fish_complete_path[2..-1]
           end
 
           # Source initialization code if it exists.
-          if test -d $plugin_dir"/conf.d"
+          if test -d $plugin_dir/conf.d
             source $plugin_dir/conf.d/*.fish
           end
 
-          if test -f $plugin_dir"/key_bindings.fish"
-            source $plugin_dir"/key_bindings.fish"
+          if test -f $plugin_dir/key_bindings.fish
+            source $plugin_dir/key_bindings.fish
           end
 
-          if test -f $plugin_dir"/init.fish"
-            source $plugin_dir"/init.fish"
+          if test -f $plugin_dir/init.fish
+            source $plugin_dir/init.fish
           end
         '';
         }) cfg.plugins));

--- a/tests/modules/programs/fish/plugins.nix
+++ b/tests/modules/programs/fish/plugins.nix
@@ -11,25 +11,25 @@ let
     set -l plugin_dir ${fooPluginSrc}
 
     # Set paths to import plugin components
-    if test -d $plugin_dir"/functions"
-      set fish_function_path $fish_function_path[1] $plugin_dir"/functions" $fish_function_path[2..-1]
+    if test -d $plugin_dir/functions
+      set fish_function_path $fish_function_path[1] $plugin_dir/functions $fish_function_path[2..-1]
     end
 
-    if test -d $plugin_dir"/completions"
-      set fish_complete_path $fish_function_path[1] $plugin_dir"/completions" $fish_complete_path[2..-1]
+    if test -d $plugin_dir/completions
+      set fish_complete_path $fish_function_path[1] $plugin_dir/completions $fish_complete_path[2..-1]
     end
 
     # Source initialization code if it exists.
-    if test -d $plugin_dir"/conf.d"
+    if test -d $plugin_dir/conf.d
       source $plugin_dir/conf.d/*.fish
     end
 
-    if test -f $plugin_dir"/key_bindings.fish"
-      source $plugin_dir"/key_bindings.fish"
+    if test -f $plugin_dir/key_bindings.fish
+      source $plugin_dir/key_bindings.fish
     end
 
-    if test -f $plugin_dir"/init.fish"
-      source $plugin_dir"/init.fish"
+    if test -f $plugin_dir/init.fish
+      source $plugin_dir/init.fish
     end
   '';
 

--- a/tests/modules/programs/fish/plugins.nix
+++ b/tests/modules/programs/fish/plugins.nix
@@ -21,7 +21,7 @@ let
 
     # Source initialization code if it exists.
     if test -d $plugin_dir"/conf.d"
-      source $plugin_dir"/conf.d/*.fish"
+      source $plugin_dir/conf.d/*.fish
     end
 
     if test -f $plugin_dir"/key_bindings.fish"


### PR DESCRIPTION
Just a few things I'd like to get in for the fish plugins PR.

* calls `escapeShellArg` on abbrs and aliases in order to allow apostrophes in the definition (some of my abbrs contain these)
* fixes sourcing of fish files in `conf.d` -- the quoting was the problem
* prepends the fenv function dir instead of concatenating the original array with that function dir (looks better IMO, but functionally equivalent -- feel free to drop that commit)